### PR TITLE
Only import the mock module on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
-python:
-    - "2.7"
-    - "3.6"
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-coveralls
+    - python: 3.6
+      env: TOXENV=py36-coveralls
 install:
-    - pip install tox-travis
+    - pip install tox
 script:
-    - tox -e coveralls
+    - tox

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -19,7 +19,10 @@ import unittest
 import filecmp
 import shutil
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from shaptools import hana
 

--- a/tests/shell_test.py
+++ b/tests/shell_test.py
@@ -18,7 +18,10 @@ import logging
 import unittest
 import subprocess
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from shaptools import shell
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,39 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py36
+envlist = py{27,36}
+
+[base]
+deps =
+    pylint
+    pytest
+    pytest-cov
 
 [testenv]
 changedir=tests
 deps =
-    pylint
-    pytest
-    pytest-cov
-    mock
+    {[base]deps}
+    py27: mock
 
 commands =
     py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term --cov-report html
 
-[testenv:coveralls]
+[testenv:py27-coveralls]
 passenv = TRAVIS TRAVIS_*
 changedir=tests
 deps =
-    pylint
-    pytest
-    pytest-cov
+    {[base]deps}
     mock
+    coveralls
+
+commands =
+    py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term
+    coveralls
+
+[testenv:py36-coveralls]
+passenv = TRAVIS TRAVIS_*
+changedir=tests
+deps =
+    {[base]deps}
     coveralls
 
 commands =


### PR DESCRIPTION
The module has been added to the standard
library unittest module as unittest.mock.