### PR TITLE
Fixes for the test setup

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+version: "2"
+checks:
+  method-complexity:
+    config:
+      threshold: 8
+  file-lines:
+    config:
+      threshold: 1024

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     py27: mock
 
 commands =
-    py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term --cov-report html
+    py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term --cov-report html {posargs}
 
 [testenv:py27-coveralls]
 passenv = TRAVIS TRAVIS_*
@@ -26,7 +26,7 @@ deps =
     coveralls
 
 commands =
-    py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term
+    py.test -vv --cov=shaptools --cov-config .coveragerc --cov-report term {posargs}
     coveralls
 
 [testenv:py36-coveralls]


### PR DESCRIPTION
This enables passing extra arguments to pytest, to allow debugging of test cases. I also modified the code climate configuration which was (in my opinion) overly restrictive. Max 255 lines in a file!?