### PR TITLE
Refactor methods on ProcessResult into free functions

### DIFF
--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -190,8 +190,9 @@ class HanaInstance:
         """
         cmd = 'HDB version'
         result = self._run_hana_command(cmd)
-        version_pattern = result.find_pattern(r'\s+version:\s+(\d+.\d+.\d+).*')
-        if not version_pattern:
+        version_pattern = shell.find_pattern(
+            r'\s+version:\s+(\d+.\d+.\d+).*', result.output)
+        if version_pattern is None:
             raise HanaError('Version pattern not found in command output')
         return version_pattern.group(1)
 
@@ -211,7 +212,7 @@ class HanaInstance:
 
     def get_sr_state(self):
         """
-        Get system replication status in th current node
+        Get system replication status in the current node
 
         Returns:
             SrStates: System replication state
@@ -219,9 +220,10 @@ class HanaInstance:
         cmd = 'hdbnsutil -sr_state'
         result = self._run_hana_command(cmd)
 
-        if result.find_pattern('.*mode: primary.*'):
+        if shell.find_pattern('.*mode: primary.*', result.output) is not None:
             return SrStates.PRIMARY
-        if result.find_pattern('.*mode: ({})'.format('|'.join(self.SYNCMODES))):
+        if shell.find_pattern('.*mode: ({})'.format('|'.join(self.SYNCMODES)),
+                              result.output) is not None:
             return SrStates.SECONDARY
         return SrStates.DISABLED
 

--- a/shaptools/shell.py
+++ b/shaptools/shell.py
@@ -29,38 +29,41 @@ class ProcessResult:
     """
 
     def __init__(self, cmd, returncode, output, err):
-        self._logger = logging.getLogger(__name__)
         self.cmd = cmd
         self.returncode = returncode
         self.output = output.decode() # Make it compatiable with python2 and 3
         self.err = err.decode()
 
-    def show_output(self):
-        """
-        Log process stdout and stderr text
-        """
-        if self.output:
-            for line in self.output.splitlines():
-                self._logger.info(line)
-        if self.err:
-            for line in self.err.splitlines():
-                self._logger.error(line)
 
-    def find_pattern(self, pattern):
-        """
-        Find pattern in output string
+def log_command_results(stdout, stderr):
+    """
+    Log process stdout and stderr text
+    """
+    logger = logging.getLogger(__name__)
+    if stdout:
+        for line in stdout.splitlines():
+            logger.info(line)
+    if stderr:
+        for line in stderr.splitlines():
+            logger.error(line)
 
-        Args:
-            pattern (str): Regular expression pattern
 
-        Returns:
-            bool: True if the pattern is found, False otherwise
-        """
-        for line in self.output.splitlines():
-            found = re.match(pattern, line)
-            if found:
-                return found
-        return False
+def find_pattern(pattern, text):
+    """
+    Find pattern in multiline string
+
+    Args:
+        pattern (str): Regular expression pattern
+        text (str): string to search in
+
+    Returns:
+        Match object if the pattern is found, None otherwise
+    """
+    for line in text.splitlines():
+        found = re.match(pattern, line)
+        if found:
+            return found
+    return None
 
 
 def format_su_cmd(cmd, user):
@@ -108,6 +111,6 @@ def execute_cmd(cmd, user=None, password=None):
     out, err = proc.communicate(input=password)
 
     result = ProcessResult(cmd, proc.returncode, out, err)
-    result.show_output()
+    log_command_results(out, err)
 
     return result


### PR DESCRIPTION
Generally, I prefer using free functions in Python
rather than methods where that makes sense: It is
easier to reuse functions than methods, since
methods carry their object with them. It is also
simpler to test since all inputs and outputs are
arguments and returns rather than object state.

It also tends to make the code simpler and more
straight-forward.